### PR TITLE
luisc09/fix/docker-cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /yasna
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 COPY *.py ./
-CMD ["python", "main.py"]
+CMD ["python", "/yasna/main.py"]


### PR DESCRIPTION
fix: github actions overrides the workdir when they are invoked. Adding the full path to main.py solves the issue that main.py is not found