### PR TITLE
fix: url for commits was wrong

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ class Yasna:
         """
         logger.info("setting up footer information")
         return {
-            "footer": "<https://wizeline.com|Powered by Wizeline SRE Team>",
+            "footer": "<https://www.wizeline.com|Powered by Wizeline SRE Team>",
             "footer_icon": "https://www.wizeline.com/favicon.ico",
         }
 

--- a/main.py
+++ b/main.py
@@ -66,7 +66,7 @@ class Yasna:
         origin = {
             "title": "Branch",
             "ref": config.ref,
-            "url": f"{config.base_url}/{config.sha}",
+            "url": f"{config.base_url}/commit/{config.sha}",
         }
         logger.debug("event type is %s", config.event)
         if config.event == "pull_request":


### PR DESCRIPTION
The URL when the event is push was wrong, it missed `/commit/` between the SHA and the base url. 
It also add `www` to the wizeline url as it was being redirected to a url that does not match with the ssl cert. 